### PR TITLE
Raise an exception if Solr returns an exception in the result body

### DIFF
--- a/sqlalchemy_solr/solrdbapi/_solrdbapi.py
+++ b/sqlalchemy_solr/solrdbapi/_solrdbapi.py
@@ -138,6 +138,8 @@ class Cursor(object):
             raise ProgrammingError(result.json().get("errorMessage", "ERROR"), result.status_code)
         else:
             rows = result.json()["result-set"]['docs']
+            if "EXCEPTION" in rows[0]:
+                raise Exception(rows[0]["EXCEPTION"])
             columns = []
             if "EOF" in rows[-1]:
                 del rows[-1]


### PR DESCRIPTION
Running under Solr 8.7.0 (at least), SQL errors return a 200 HTTP status code but report the exception as a row in the results. This small patch looks for that error and raises it so the caller can understand why the call failed.