### PR TITLE
Add support for Bearer Token Authorization in Solr SQLAlchemy driver

### DIFF
--- a/sqlalchemy_solr/solrdbapi/_solrdbapi.py
+++ b/sqlalchemy_solr/solrdbapi/_solrdbapi.py
@@ -111,7 +111,6 @@ class Cursor:
             + "/sql",
             params=local_payload,
             headers=_HEADER,
-            auth=(username, password),
         )
 
     @connected
@@ -348,6 +347,7 @@ def connect(
     use_ssl=False,
     verify_ssl=False,
     ca_certs=None,
+    token=None,
 ):
 
     session = Session()
@@ -369,12 +369,12 @@ def connect(
     if collection is not None:
         local_url = "/" + server_path + "/" + collection + "/select"
 
+        add_authorization(session, username, password, token)
         response = session.get(
             "{proto}{host}:{port}{url}".format(
                 proto=proto, host=host, port=str(port), url=local_url
             ),
             headers=_HEADER,
-            auth=(username, password),
         )
 
         if response.status_code != 200:
@@ -387,3 +387,9 @@ def connect(
     return Connection(
         host, db, username, password, server_path, collection, port, proto, session
     )
+
+def add_authorization(session, username, password, token):
+    if token is not None:
+        session.headers.update({'Authorization': f'Bearer {token}'})
+    else:
+        session.auth = (username, password)

--- a/sqlalchemy_solr/solrdbapi/solr_reflect.py
+++ b/sqlalchemy_solr/solrdbapi/solr_reflect.py
@@ -28,7 +28,7 @@ class SolrTableReflection:
 
         for table in tables:
             if table not in SolrTableReflection.table_metadata_cache:
-                session = Session()
+                session = SolrTableReflection.connection._session
 
                 result = session.get(
                     SolrTableReflection.connection.proto
@@ -41,10 +41,6 @@ class SolrTableReflection:
                     + table
                     + "/admin/luke",
                     headers=_HEADER,
-                    auth=(
-                        SolrTableReflection.connection.username,
-                        SolrTableReflection.connection.password,
-                    ),
                 )
                 fields = result.json()["fields"]
 


### PR DESCRIPTION
This commit introduces support for using bearer tokens as part of the authentication mechanism in the SQLAlchemy Solr driver. The changes include:

- Added a new method to handle the creation of a session with proper authorization, allowing the use of bearer tokens.
- Updated the existing authentication logic to conditionally include the bearer token in the authorization headers.
- Ensured that the session can be utilized in other methods within the class.
@aadel 