### PR TITLE
Fixed: ssl conditions in http.py

### DIFF
--- a/sqlalchemy_solr/http.py
+++ b/sqlalchemy_solr/http.py
@@ -90,10 +90,11 @@ class SolrDialect_http(SolrDialect):
             # Prepare a session with proper authorization handling.
             session = Session()
             #session.verify property which is bydefault true so Handled here
-            session.verify = False
-            if "verify_ssl" in url.query and url.query["verify_ssl"] in [True, "True", "true"]:
+            if "verify_ssl" in url.query and url.query["verify_ssl"] in [False, "False", "false"]:
+                session.verify = False
+            else:
                 if "ca_certs" in url.query and url.query["ca_certs"] is not None:
-                    session.verify = url.query["ca_certs"]
+                    session.cert = url.query["ca_certs"]
                 else:
                     session.verify = True
 

--- a/sqlalchemy_solr/http.py
+++ b/sqlalchemy_solr/http.py
@@ -92,11 +92,6 @@ class SolrDialect_http(SolrDialect):
             #session.verify property which is bydefault true so Handled here
             if "verify_ssl" in url.query and url.query["verify_ssl"] in [False, "False", "false"]:
                 session.verify = False
-            else:
-                if "ca_certs" in url.query and url.query["ca_certs"] is not None:
-                    session.cert = url.query["ca_certs"]
-                else:
-                    session.verify = True
 
             if self.token is not None:
                 session.headers.update({'Authorization': f'Bearer {self.token}'})

--- a/sqlalchemy_solr/http.py
+++ b/sqlalchemy_solr/http.py
@@ -60,9 +60,8 @@ class SolrDialect_http(SolrDialect):
             db = ".".join(db_parts)
 
             self.proto = "http://"
-
-            if "use_ssl" in kwargs:
-                if kwargs["use_ssl"] in [True, "True", "true"]:
+            if "use_ssl" in url.query:
+                if url.query["use_ssl"] in [True, "True", "true"]:
                     self.proto = "https://"
 
             if "token" in url.query:
@@ -90,6 +89,13 @@ class SolrDialect_http(SolrDialect):
 
             # Prepare a session with proper authorization handling.
             session = Session()
+            #session.verify property which is bydefault true so Handled here
+            session.verify = False
+            if "verify_ssl" in url.query and url.query["verify_ssl"] in [True, "True", "true"]:
+                if "ca_certs" in url.query and url.query["ca_certs"] is not None:
+                    session.verify = url.query["ca_certs"]
+                else:
+                    session.verify = True
 
             if self.token is not None:
                 session.headers.update({'Authorization': f'Bearer {self.token}'})

--- a/sqlalchemy_solr/solrdbapi/_solrdbapi.py
+++ b/sqlalchemy_solr/solrdbapi/_solrdbapi.py
@@ -345,7 +345,7 @@ def connect(
     server_path="solr",
     collection=None,
     use_ssl=False,
-    verify_ssl=False,
+    verify_ssl=None,
     ca_certs=None,
     token=None,
 ):
@@ -353,11 +353,11 @@ def connect(
     session = Session()
     mf = MessageFormatter()
 
-    if verify_ssl is False:
+    if verify_ssl is not None and verify_ssl in [False,"False","false"]:
         session.verify = False
     else:
         if ca_certs is not None:
-            session.verify = ca_certs
+            session.cert = ca_certs
         else:
             session.verify = True
 

--- a/sqlalchemy_solr/solrdbapi/_solrdbapi.py
+++ b/sqlalchemy_solr/solrdbapi/_solrdbapi.py
@@ -346,20 +346,14 @@ def connect(
     collection=None,
     use_ssl=False,
     verify_ssl=None,
-    ca_certs=None,
     token=None,
 ):
 
     session = Session()
     mf = MessageFormatter()
-
+    # bydefault session.verify is set to True
     if verify_ssl is not None and verify_ssl in [False,"False","false"]:
         session.verify = False
-    else:
-        if ca_certs is not None:
-            session.cert = ca_certs
-        else:
-            session.verify = True
 
     if use_ssl in [True, "True", "true"]:
         proto = "https://"


### PR DESCRIPTION
Previously, when SSL was enabled, self.proto was not set, causing issues with functions like get_table_names, and get_columns.

- Fixed the Use_ssl condition, which was previously not supported when using kwargs.
- By default, session.verify is set to true; now, it is set to false. If verify_ssl is true, then enable it.

@aadel 


